### PR TITLE
Fix error when there is no a:t element in the xml

### DIFF
--- a/pptx-export-notes.py
+++ b/pptx-export-notes.py
@@ -37,6 +37,9 @@ def run():
         #parse each XML notes file from the notes folder.
         dom = parse(infile)
         noteslist = dom.getElementsByTagName('a:t')
+        if len(noteslist) == 0:
+            continue
+
         #separate last element of noteslist for use as the slide marking.
         slideNumber = noteslist.pop()
         slideNumber = slideNumber.toxml().replace('<a:t>', '').replace('</a:t>', '')


### PR DESCRIPTION
I got the following error:

/pptx-export-notes.py", line xx, in run
    slideNumber = noteslist.pop()
IndexError: pop from empty list

The notes xml in question seemed to have no a:t element in the xml. Checking if the list is non-empty solved this issue.