### PR TITLE
Get slide numbers from xml filename; wrap file access in with block; …

### DIFF
--- a/pptx-export-notes.py
+++ b/pptx-export-notes.py
@@ -13,6 +13,14 @@ from zipfile import ZipFile
 from xml.dom.minidom import parse
 
 
+def slide_number_from_xml_file(filename):
+    """
+    Integer slide number from filename
+
+    Assumes /path/to/Slidefile/somekindofSlide36.something
+    """
+    return int(filename[filename.rfind("Slide") + 5:filename.rfind(".")])
+
 #main function
 def run():
     parser = argparse.ArgumentParser(description='exports speaker notes from pptx files by parsing the XML')
@@ -31,38 +39,39 @@ def run():
     writepath = os.path.dirname(args.pptxfile.name) + '/' + os.path.basename(args.pptxfile.name).rsplit('.', 1)[
         0] + '_presenter_notes.txt'
     print writepath
-    f = open(writepath, 'w')
 
-    for infile in glob.glob(os.path.join(path, '*.xml')):
-        #parse each XML notes file from the notes folder.
-        dom = parse(infile)
-        noteslist = dom.getElementsByTagName('a:t')
-        if len(noteslist) == 0:
-            continue
+    # Get the xml we extracted from the zip file
+    xmlfiles = glob.glob(os.path.join(path, '*.xml'))
 
-        #separate last element of noteslist for use as the slide marking.
-        slideNumber = noteslist.pop()
-        slideNumber = slideNumber.toxml().replace('<a:t>', '').replace('</a:t>', '')
-        #start with this empty string to build the presenter note itself
-        tempstring = ''
+    with open(writepath, 'w') as f:
+        for infile in sorted(xmlfiles, key=slide_number_from_xml_file):
+            #parse each XML notes file from the notes folder.
+            dom = parse(infile)
+            noteslist = dom.getElementsByTagName('a:t')
+            if len(noteslist) == 0:
+                continue
 
-        for node in noteslist:
-            xmlTag = node.toxml()
-            xmlData = xmlTag.replace('<a:t>', '').replace('</a:t>', '')
-            #concatenate the xmlData to the tempstring for the particular slideNumber index.
-            tempstring = tempstring + xmlData
+            #separate last element of noteslist for use as the slide marking.
+            slideNumber = slide_number_from_xml_file(infile)
+            #start with this empty string to build the presenter note itself
+            tempstring = ''
 
-        #store the tempstring in the dictionary under the slide number
-        notesDict[slideNumber] = tempstring
+            for node in noteslist:
+                xmlTag = node.toxml()
+                xmlData = xmlTag.replace('<a:t>', '').replace('</a:t>', '')
+                #concatenate the xmlData to the tempstring for the particular slideNumber index.
+                tempstring = tempstring + xmlData
 
-    #print/write the dictionary to file in sorted order by key value.
-    for x in [key for key in sorted(notesDict.keys(), key=int)]:
-        f.write('Slide ' + str(x) + '\n')
-        stringybean = notesDict[str(x)]
-        f.write(stringybean.encode('ascii', 'ignore') + '\n')
+            #store the tempstring in the dictionary under the slide number
+            notesDict[slideNumber] = tempstring
 
-    f.close()
-    print 'file successfully written to' + '\'' + writepath + '\''
+        #print/write the dictionary to file in sorted order by key value.
+        for x in [key for key in sorted(notesDict.keys(), key=int)]:
+            f.write('Slide ' + str(x) + '\n')
+            notes_string = notesDict[x]
+            f.write(notes_string.encode('utf-8', 'ignore') + '\n')
+
+        print 'file successfully written to' + '\'' + writepath + '\''
 
 
 if __name__ == "__main__":
@@ -70,7 +79,4 @@ if __name__ == "__main__":
         run()
     except (KeyboardInterrupt, SystemExit):
         raise
-    except:
-        print'something wrong happened'
-        # report error and proceed
 


### PR DESCRIPTION
…report Python errors

I've made two small changes and one big change.

One big change:

The slide number wasn't coming from where the original code thought it should be coming from, so I'm now getting the slide number from the .xml filename. This should (might?) be more robust.

Two small changes:
1. File read/writes should always be wrapped in `with` clauses.
2. Getting "something wrong happened" is probably less useful than seeing the actual Python error. Chances are, if someone has got as far as running this script at all, they are cool with seeing Python errors.
